### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -1,5 +1,8 @@
 name: backend
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/hatohui/GenCare/security/code-scanning/1](https://github.com/hatohui/GenCare/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the workflow's steps, it primarily reads repository contents (e.g., for checking out code and restoring dependencies) and does not appear to require any write permissions. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
