### PR TITLE
[BE] feat: Allow NULL values for password_hash in account table

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS "account" (
     "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     "role_id" UUID NOT NULL,
     "email" VARCHAR(255) NOT NULL UNIQUE,
-    "password_hash" TEXT NOT NULL,
+    "password_hash" TEXT ,
     "first_name" VARCHAR(100),
     "last_name" VARCHAR(100),
     "phone" VARCHAR(20),


### PR DESCRIPTION
feat: Allow NULL values for password_hash in account table

Modified the `password_hash` column in the `account` table
to remove the `NOT NULL` constraint, permitting it to be
empty or not provided during record insertion.